### PR TITLE
Update post.php

### DIFF
--- a/site/templates/post.php
+++ b/site/templates/post.php
@@ -15,7 +15,7 @@
                                      'author'     => true,
                                      'avatar'     => true,
                                      'tags'       => true,
-                                     'categories' => true)) ?>
+                                     'category' => true)) ?>
 
   <?= getCoverImage($post) ?>
 


### PR DESCRIPTION
_post-footer_ snippet expects category variable to be passed as **category**, currently is passed as **categories** (This is the naming scheme used for the _archive_ template
