### PR TITLE
Fixed broken links on kirby installs in a subdirectory

### DIFF
--- a/site/config/config.php
+++ b/site/config/config.php
@@ -29,6 +29,9 @@ c::set('pagination-posts', 10);
 c::set('pagination-archive', 30);
 c::set('pagination-search', 30);
 
+/* where's the blog? */
+c::set('posts', 'posts');
+
 /*
 
 ---------------------------------------
@@ -42,9 +45,6 @@ of the system, please check out http://getkirby.com/docs/advanced/options
 */
 
 c::set('markdown.extra', true);
-
-/* where's the blog? */
-c::set('posts', 'posts');
 c::set('debug', 'true');
 
 c::set('routes', array(

--- a/site/config/config.php
+++ b/site/config/config.php
@@ -42,7 +42,9 @@ of the system, please check out http://getkirby.com/docs/advanced/options
 */
 
 c::set('markdown.extra', true);
-c::set('home', 'posts');
+
+/* where's the blog? */
+c::set('posts', 'posts');
 c::set('debug', 'true');
 
 c::set('routes', array(
@@ -78,7 +80,7 @@ c::set('routes', array(
     'pattern' => '(:num)/(:num)/(:num)/(:any)',
     'action'  => function($year, $month, $day, $uid) {
 
-      $page = page('posts/' . $uid);
+      $page = page(c::get('posts') . '/' . $uid);
       if(!$page){
         $page = site()->errorPage();
       } else {

--- a/site/controllers/archive.php
+++ b/site/controllers/archive.php
@@ -3,7 +3,7 @@
 return function($site, $pages, $page, $data) {
 
   // get all posts
-  $posts = $site->find('posts')->children()
+  $posts = $site->find(c::get('posts'))->children()
                                ->visible()
                                ->flip();
 

--- a/site/controllers/search.php
+++ b/site/controllers/search.php
@@ -15,7 +15,7 @@ return function($site, $pages, $page) {
         break;
 
       default:
-        $results = $site->find('posts')
+        $results = $site->find(c::get('posts'))
                       ->search($query, array('words' => true))
                       ->visible();
         break;
@@ -28,7 +28,7 @@ return function($site, $pages, $page) {
 
 
   //pass all variables to the template
-  return compact('results', 'query');
+  return compact('results', 'query', 'pagination');
 
 };
 

--- a/site/plugins/helpers.php
+++ b/site/plugins/helpers.php
@@ -75,7 +75,7 @@ function getCoverImage($post) {
  */
 function getDatesArchive() {
   $site = site();
-  $posts = $site->find('posts')->children()->visible();
+  $posts = $site->find(c::get('posts'))->children()->visible();
 
   if($posts->count() > 0) {
     foreach ($posts as $post) {
@@ -99,7 +99,7 @@ function getDatesArchive() {
  * @return array
  */
 function getTagsArchive() {
-  return tagcloud(page('posts'), array('field'   => 'tags',
+  return tagcloud(page(c::get('posts')), array('field'   => 'tags',
                                        'param'   => 'tag',
                                        'baseurl' => ''));
 }
@@ -112,7 +112,7 @@ function getTagsArchive() {
  * @return array
  */
 function getCategoriesArchive() {
-  return tagcloud(page('posts'), array('field'   => 'category',
+  return tagcloud(page(c::get('posts')), array('field'   => 'category',
                                        'param'   => 'category',
                                        'baseurl' => ''));
 }
@@ -125,7 +125,7 @@ function getCategoriesArchive() {
  * @return array
  */
 function getAuthorsArchive() {
-  return tagcloud(page('posts'), array('field'   => 'author',
+  return tagcloud(page(c::get('posts')), array('field'   => 'author',
                                        'param'   => 'author',
                                        'baseurl' => ''));
 }

--- a/site/snippets/archive-categories.php
+++ b/site/snippets/archive-categories.php
@@ -8,7 +8,7 @@
     <ul>
     <?php foreach($categories as $category): ?>
       <li>
-        <a href="<?php echo $category->url() ?>">
+        <a href="<?php echo $site->url() . $category->url() ?>">
           <?php echo $category->name() ?> (<?= $category->results() ?>)
         </a>
       </li>

--- a/site/snippets/archive-dates.php
+++ b/site/snippets/archive-dates.php
@@ -10,7 +10,7 @@ if(!isset($class)) $class = false;
   <ul>
   <?php foreach ($dates as $year => $months): ?>
     <li>
-      <a href="/<?= $year ?>">
+      <a href="<?= $site->url() . '/' . $year ?>">
         <?= $year ?>
       </a>
       <ul>

--- a/site/snippets/archive-tags.php
+++ b/site/snippets/archive-tags.php
@@ -8,7 +8,7 @@
   <ul>
   <?php foreach($tags as $tag): ?>
     <li>
-      <a href="<?php echo $tag->url() ?>">
+      <a href="<?php echo $site->url() . $tag->url() ?>">
         <?php echo $tag->name() ?> (<?= $tag->results() ?>)
       </a>
     </li>

--- a/site/snippets/nav-main.php
+++ b/site/snippets/nav-main.php
@@ -6,7 +6,7 @@
         <a href="<?= $page->url() ?>">
           <?= $page->title()->html() ?>
         </a>
-        <?php if($page->hasVisibleChildren() && $page->uid() != 'posts'): ?>
+        <?php if($page->hasVisibleChildren() && $page->uid() != c::get('posts')): ?>
           <ul>
             <?php foreach($page->children()->visible() as $child): ?>
               <li <?php e($child->isActive(),' class="active"') ?>>

--- a/site/templates/search.php
+++ b/site/templates/search.php
@@ -39,6 +39,8 @@
 
       <?php endforeach ?>
 
+      <?php snippet('nav-pagination') ?>
+
   <?php else: ?>
     <?= $page->noposts()->kirbytext() ?>
   <?php endif ?>


### PR DESCRIPTION
These changes make the anchor URLs work for categories, dates and tags independent from whether kirby is installed in the web server root directory or a subdirectory.